### PR TITLE
allow passing of primitive JSON compatible types too

### DIFF
--- a/lib/quip.js
+++ b/lib/quip.js
@@ -124,7 +124,7 @@ module.exports = function (req, res, next) {
                 res._quip_headers['Content-Length'] = data.length
             }
             else {
-                if (typeof data === 'object') {
+                if (!(data instanceof Buffer)) {
                     // assume data is JSON if passed an object (not a buffer)
                     if (!res._quip_headers['Content-Type']) {
                         res._quip_headers['Content-Type'] = 'application/json';


### PR DESCRIPTION
The test of `typeof data == 'object` prevents plain primitive types such as `number` and `boolean` from being serialised correctly unless they're wrapped up in a higher level object.  This patch resolves that.